### PR TITLE
Add /haiku endpoint to return a haiku

### DIFF
--- a/main.go
+++ b/main.go
@@ -62,6 +62,7 @@ func main() {
 	r.Handle("/metrics", promhttp.Handler())
 
 	r.Get("/ping", s.pingPong)
+	r.Get("/haiku", s.haikuHandler)
 
 	r.Route("/api", func(t chi.Router) {
 		t.Get("/user_id/{user_id:[a-z0-9-.]+}", s.getUserItems)
@@ -121,4 +122,9 @@ func (s Serving) addItemToUser(w http.ResponseWriter, r *http.Request) {
 func (s Serving) pingPong(w http.ResponseWriter, r *http.Request) {
 	render.Status(r, http.StatusOK)
 	render.PlainText(w, r, "Pong\n")
+}
+
+func (s Serving) haikuHandler(w http.ResponseWriter, r *http.Request) {
+	render.Status(r, http.StatusOK)
+	render.PlainText(w, r, "Old silent pond...\nA frog jumps into the pond,\nsplash! Silence again.")
 }

--- a/main_test.go
+++ b/main_test.go
@@ -80,6 +80,27 @@ func Test_run(t *testing.T) {
 		t.Errorf("Expected: %d. Got: %d, Message: %s", http.StatusOK, rr.Code, rr.Body)
 	}
 
+	// Check the response body
+	expected := "Pong\n"
+	assert.Equal(t, expected, rr.Body.String(), "handler returned unexpected body")
+
+}
+
+func TestHaikuHandler(t *testing.T) {
+	req, err := http.NewRequest("GET", "/haiku", nil)
+	assert.Nil(t, err)
+
+	rr := httptest.NewRecorder()
+	// Use fakeServing which is already initialized
+	handler := http.HandlerFunc(fakeServing.haikuHandler)
+	handler.ServeHTTP(rr, req)
+
+	// Check the status code
+	assert.Equal(t, http.StatusOK, rr.Code, fmt.Sprintf("handler returned wrong status code: got %v want %v", rr.Code, http.StatusOK))
+
+	// Check the response body
+	expectedHaiku := "Old silent pond...\nA frog jumps into the pond,\nsplash! Silence again."
+	assert.Equal(t, expectedHaiku, rr.Body.String(), "handler returned unexpected body")
 }
 
 func Test_createUser(t *testing.T) {


### PR DESCRIPTION
This change introduces a new HTTP GET endpoint at `/haiku`. When accessed, this endpoint returns a static, multi-line haiku string with an HTTP 200 OK status.

The following changes were made:
- Added a `haikuHandler` function in `main.go` to handle requests to the new endpoint.
- Registered the `/haiku` route in `main.go` to point to `haikuHandler`.
- Added `TestHaikuHandler` in `main_test.go` to verify the endpoint's functionality, checking for the correct status code and response body.